### PR TITLE
[LG-4095] Refactor specs to use in-memory SQLite and shoulda-matchers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
     rubocop-rspec (1.26.0)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.10.1)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -72,6 +75,8 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (= 0.75)
   rubocop-rspec
+  shoulda-matchers
+  sqlite3
 
 BUNDLED WITH
    1.17.3

--- a/identity_validations.gemspec
+++ b/identity_validations.gemspec
@@ -44,5 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '=0.75'
   spec.add_development_dependency 'rubocop-rspec'
-
+  spec.add_development_dependency 'shoulda-matchers'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/lib/identity_validations/version.rb
+++ b/lib/identity_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityValidations
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/identity_validations/test_service_provider.rb
+++ b/spec/identity_validations/test_service_provider.rb
@@ -6,33 +6,29 @@ require 'active_model/validations'
 require 'active_record'
 require 'active_record/validations'
 
+ActiveRecord::Base.establish_connection(
+  adapter: 'sqlite3',
+  database: ':memory:'
+)
+
+ActiveRecord::Schema.define do
+  create_table :test_service_providers, force: true do |t|
+    t.string 'issuer', null: false
+    t.string 'friendly_name'
+    t.integer 'ial'
+    t.string 'redirect_uris'
+    t.text 'failure_to_proof_url'
+    t.string 'push_notification_url'
+    t.string 'certs'
+  end
+end
+
 module IdentityValidations
-  class TestServiceProvider
-    include ::ActiveModel::Model
-    include ::ActiveModel::Validations
-    include ::ActiveRecord::Validations
+  class TestServiceProvider < ActiveRecord::Base
     include IdentityValidations::ServiceProviderValidation
 
-    attr_accessor :friendly_name,
-                  :issuer,
-                  :ial,
-                  :redirect_uris,
-                  :failure_to_proof_url,
-                  :push_notification_url,
-                  :certs
-
-    def initialize(**args)
-      super
-    end
-
-    # needed to get validations to run
-    def new_record?
-      true
-    end
-
-    # needed to get validations to run
-    def self._reflect_on_association(_foo)
-      false
-    end
+    # we need to serialize since SQLite doesn't support arrays
+    serialize :redirect_uris, Array
+    serialize :certs, Array
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'bundler/setup'
 require 'byebug'
 require 'identity_validations'
 require 'identity_validations/test_service_provider'
+require 'shoulda-matchers'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -14,5 +15,13 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :active_model
+    with.library :active_record
   end
 end


### PR DESCRIPTION
Release v0.5.0

Part of LG-4095, removing duplicate code and specs from the IdP and into
the gem. While doing so it seemed to make sense to clean things up a bit
so we added the in-memory SQLite trick from 18F/identity-idp-config to
use normal ActiveRecord and added Shoulda Matchers. The cert specs were
a little more involved so we left those alone for now.