### PR TITLE
[LG-4676] Improve certificate validation error messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity_validations (0.5.0)
+    identity_validations (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/identity_validations/service_provider_validation.rb
+++ b/lib/identity_validations/service_provider_validation.rb
@@ -55,9 +55,10 @@ module IdentityValidations
       Array(certs).each do |cert|
         content = cert_content(cert)
         next if content.blank?
+
         OpenSSL::X509::Certificate.new(content)
-      rescue OpenSSL::X509::CertificateError
-        errors.add(:certs, :invalid)
+      rescue OpenSSL::X509::CertificateError => e
+        errors.add(:certs, "#{cert} is invalid - #{e.message}")
       end
     end
 

--- a/lib/identity_validations/version.rb
+++ b/lib/identity_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityValidations
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
Resolves LG-4676

* Add the specific certificate filename and the associated error for
  invalid certs so it's easier to tell what the issue is.
* Release v0.6.0