### PR TITLE
[LG-4933] Fix edge case in redirect_uri validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity_validations (0.7.0)
+    identity_validations (0.7.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/identity_validations/service_provider_validation.rb
+++ b/lib/identity_validations/service_provider_validation.rb
@@ -73,6 +73,7 @@ module IdentityValidations
 
     def uri_custom_scheme_only?(uri)
       parsed_uri = URI.parse(uri)
+      return false if unsupported_uri?(parsed_uri)
       return false if /\Ahttps?/ =~ parsed_uri.scheme
 
       parsed_uri.scheme.present?

--- a/lib/identity_validations/version.rb
+++ b/lib/identity_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityValidations
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end

--- a/spec/identity_validations/service_provider_validation_spec.rb
+++ b/spec/identity_validations/service_provider_validation_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe IdentityValidations::ServiceProviderValidation, type: :model do
       'http://this has spaces',
       'foo.com',
       '/foo/bar',
-      'foo.com:result',
       'file:///usr/sbin/evil_script.sh',
       'ftp://user@password:example.com/usr/sbin/evil_script.sh',
       'mailto:sally@example.com?subject=Invalid',
@@ -63,8 +62,14 @@ RSpec.describe IdentityValidations::ServiceProviderValidation, type: :model do
   end
   it { is_expected.not_to allow_value('issuer with space').for(:issuer).on(:create) }
   it { is_expected.to validate_inclusion_of(:ial).in_array([1, 2]).allow_nil }
-  it { is_expected.to allow_value(valid_urls << 'random.scheme:', [], nil).for(:redirect_uris) }
-  it { is_expected.not_to allow_value(invalid_urls << 'https:').for(:redirect_uris) }
+  it { is_expected.to allow_value((valid_urls << 'random.scheme:'), [], nil).for(:redirect_uris) }
+  it 'correctly validates redirect_uris' do
+    (invalid_urls << 'https:').each do |url|
+      # check individually since the group would be negated by any one invalid
+      # value
+      expect(subject).not_to allow_value([url]).for(:redirect_uris)
+    end
+  end
   it { is_expected.to allow_value(*valid_urls, nil).for(:failure_to_proof_url) }
   it { is_expected.not_to allow_value(*invalid_urls).for(:failure_to_proof_url) }
   it { is_expected.to allow_value(*valid_urls, nil).for(:push_notification_url) }


### PR DESCRIPTION
Resolves LG-4933

Fix a bug where the validator would permit a redirect_uri with an
unsupported scheme due to the uri_custom_scheme_only? validation. Also
fix the incorrect test that missed this by testing each invalid value
individually for redirect_uris.

Release v0.7.1