### PR TITLE
Validate redirect_uris do not contain wildcards

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity_validations (0.7.2)
+    identity_validations (0.7.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/identity_validations/service_provider_validation.rb
+++ b/lib/identity_validations/service_provider_validation.rb
@@ -12,7 +12,7 @@ module IdentityValidations
         validates :issuer, format: { with: ISSUER_FORMAT_REGEXP }, on: :create
         validates :ial, inclusion: { in: [1, 2] }, allow_nil: true
 
-        validate :redirect_uris_are_parsable
+        validate :redirect_uris_are_valid
         validate :failure_to_proof_url_is_parsable
         validate :push_notification_url_is_parsable
         validate :certs_are_x509_if_present
@@ -30,11 +30,11 @@ module IdentityValidations
     #         we just enforce uniqueness, without whitespace.
     ISSUER_FORMAT_REGEXP = /\A[\S]+\z/.freeze
 
-    def redirect_uris_are_parsable
+    def redirect_uris_are_valid
       return if redirect_uris.blank?
 
       redirect_uris.each do |uri|
-        next if uri_valid?(uri) || uri_custom_scheme_only?(uri)
+        next if !uri.include?('*') && (uri_valid?(uri) || uri_custom_scheme_only?(uri))
 
         errors.add(:redirect_uris, :invalid)
         break

--- a/lib/identity_validations/version.rb
+++ b/lib/identity_validations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityValidations
-  VERSION = '0.7.2'
+  VERSION = '0.7.3'
 end

--- a/spec/identity_validations/service_provider_validation_spec.rb
+++ b/spec/identity_validations/service_provider_validation_spec.rb
@@ -17,20 +17,6 @@ RSpec.describe IdentityValidations::ServiceProviderValidation, type: :model do
       'ldap://ldap.example.com/dc=example;dc=com?query'
     ]
   end
-  let(:invalid_redirect_urls) do
-    [
-      'not_a_url',
-      'http://this has spaces',
-      'foo.com',
-      '/foo/bar',
-      'file:///usr/sbin/evil_script.sh',
-      'ftp://user@password:example.com/usr/sbin/evil_script.sh',
-      'mailto:sally@example.com?subject=Invalid',
-      'ldap://ldap.example.com/dc=example;dc=com?query',
-      'https:*',
-      'https://app.me/*'
-    ]
-  end
   let(:nil_cert) { '' }
   let(:test_cert) do
     <<~CERT.strip
@@ -78,7 +64,7 @@ RSpec.describe IdentityValidations::ServiceProviderValidation, type: :model do
   it { is_expected.to validate_inclusion_of(:ial).in_array([1, 2]).allow_nil }
   it { is_expected.to allow_value((valid_urls << 'random.scheme:'), [], nil).for(:redirect_uris) }
   it 'correctly validates redirect_uris' do
-    (invalid_redirect_urls << 'https:').each do |url|
+    (invalid_urls << %w[https: https://* https://app.me/*]).each do |url|
       # check individually since the group would be negated by any one invalid
       # value
       expect(subject).not_to allow_value([url]).for(:redirect_uris)

--- a/spec/identity_validations/service_provider_validation_spec.rb
+++ b/spec/identity_validations/service_provider_validation_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe IdentityValidations::ServiceProviderValidation, type: :model do
       'ldap://ldap.example.com/dc=example;dc=com?query'
     ]
   end
+  let(:invalid_redirect_urls) do
+    [
+      'not_a_url',
+      'http://this has spaces',
+      'foo.com',
+      '/foo/bar',
+      'file:///usr/sbin/evil_script.sh',
+      'ftp://user@password:example.com/usr/sbin/evil_script.sh',
+      'mailto:sally@example.com?subject=Invalid',
+      'ldap://ldap.example.com/dc=example;dc=com?query',
+      'https:*',
+      'https://app.me/*'
+    ]
+  end
   let(:nil_cert) { '' }
   let(:test_cert) do
     <<~CERT.strip
@@ -64,7 +78,7 @@ RSpec.describe IdentityValidations::ServiceProviderValidation, type: :model do
   it { is_expected.to validate_inclusion_of(:ial).in_array([1, 2]).allow_nil }
   it { is_expected.to allow_value((valid_urls << 'random.scheme:'), [], nil).for(:redirect_uris) }
   it 'correctly validates redirect_uris' do
-    (invalid_urls << 'https:').each do |url|
+    (invalid_redirect_urls << 'https:').each do |url|
       # check individually since the group would be negated by any one invalid
       # value
       expect(subject).not_to allow_value([url]).for(:redirect_uris)


### PR DESCRIPTION
We should not permit partners to use redirect uris with wildcards ('*')